### PR TITLE
profiles: clarify how timestamps_unix_nano and values field interact

### DIFF
--- a/opentelemetry/proto/profiles/v1development/profiles.proto
+++ b/opentelemetry/proto/profiles/v1development/profiles.proto
@@ -369,10 +369,14 @@ message ValueType {
   AggregationTemporality aggregation_temporality = 3;
 }
 
-// Each Sample records values encountered in some program
-// context. The program context is typically a stack trace, perhaps
-// augmented with auxiliary information like the thread-id, some
-// indicator of a higher level request being handled etc.
+// Each Sample records values encountered in some program context. The program
+// context is typically a stack trace, perhaps augmented with auxiliary
+// information like the thread-id, some indicator of a higher level request
+// being handled etc.
+//
+// A Sample MUST have have at least one values or timestamps_unix_nano entry. If
+// both fields are populated, they MUST contain the same number of elements, and
+// the elements at the same index MUST refer to the same event.
 message Sample {
   // locations_start_index along with locations_length refers to to a slice of locations in Profile.location_indices.
   int32 locations_start_index = 1;
@@ -388,7 +392,7 @@ message Sample {
   optional int32 link_index = 5;
 
   // Timestamps associated with Sample represented in nanoseconds. These
-  // timestamps are expected to fall within the Profile's time range. [optional]
+  // timestamps are expected to fall within the Profile's time range.
   repeated uint64 timestamps_unix_nano = 6;
 }
 


### PR DESCRIPTION
For https://github.com/open-telemetry/opentelemetry-proto/pull/649